### PR TITLE
Merge branch-command-history to branch-delivery

### DIFF
--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -13,6 +13,16 @@ public class CommandHistory implements History {
     private List<String> commandHistory;
     private int currentCommandIndex;
     private final int lengthLimit;
+
+    // boolean value to be checked during previousCommand() method call
+    // if (hasReturnedCurrentCommandBefore) {
+    //      return previousCommand;
+    // } else {
+    //      return currentCommand;
+    // }
+    // this is to prevent the first previousCommand() method call to
+    // return commandHistory's 2nd last command instead of the last command
+    // will be reset to true if (newCommandsAdded || nextCommand() -> Optional.empty())
     private boolean hasReturnedCurrentCommandBefore;
 
     /**

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -57,7 +57,7 @@ public class CommandHistory implements History {
     }
 
     private boolean isAbleToReturnNextCommand() {
-        return currentCommandIndex < commandHistory.size() - 1 && isWithinLengthLimit();
+        return hasNextCommand() && isWithinLengthLimit();
     }
 
     private boolean isAbleToReturnPreviousCommand() {

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -13,6 +13,7 @@ public class CommandHistory implements History {
     private List<String> commandHistory;
     private int currentCommandIndex;
     private final int lengthLimit;
+    private boolean hasReturnedCurrentCommandBefore;
 
     /**
      * Constructor for CommandHistory
@@ -28,6 +29,8 @@ public class CommandHistory implements History {
 
             // since commandHistory is zero-indexed, initializing currentCommandIndex to -1 solves the zero-index issue
             this.currentCommandIndex = -1;
+
+            this.hasReturnedCurrentCommandBefore = false;
         } else {
             throw new HistoryException(MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE);
         }
@@ -61,12 +64,17 @@ public class CommandHistory implements History {
         return currentCommandIndex > 0 && isWithinLengthLimit();
     }
 
-    public boolean hasNextCommand() {
+    private boolean isCurrentCommandIndexZero() {
+        return currentCommandIndex == 0;
+    }
+
+    private boolean hasNextCommand() {
         return currentCommandIndex < commandHistory.size() - 1;
     }
 
     @Override
     public void addToHistory(String command) {
+        hasReturnedCurrentCommandBefore = false;
         if (hasNextCommand()) {
             // if there exist a next command,
             // copy commandHistory[0] to commandHistory[currentCommandIndex],
@@ -87,8 +95,13 @@ public class CommandHistory implements History {
 
     @Override
     public Optional<String> previousCommand() {
-        if (isAbleToReturnPreviousCommand()) {
+        if (!hasReturnedCurrentCommandBefore) {
+            hasReturnedCurrentCommandBefore = true;
+            return currentCommand();
+        } else if (isAbleToReturnPreviousCommand()) {
             currentCommandIndex--;
+            return Optional.of(commandHistory.get(currentCommandIndex));
+        } else if (isCurrentCommandIndexZero()) {
             return Optional.of(commandHistory.get(currentCommandIndex));
         } else {
             return Optional.empty();
@@ -97,6 +110,7 @@ public class CommandHistory implements History {
 
     @Override
     public Optional<String> nextCommand() {
+        hasReturnedCurrentCommandBefore = false;
         if (isAbleToReturnNextCommand()) {
             currentCommandIndex++;
             return Optional.of(commandHistory.get(currentCommandIndex));

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import seedu.address.history.exception.HistoryException;
 
 public class CommandHistory implements History {
-    private static final String MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE = "Length of Command History must at least be 1";
+    private static final String MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE = "Length of Command History must be at least be 1";
 
     private List<String> commandHistory;
     private int currentCommandIndex;

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import seedu.address.history.exception.HistoryException;
 
 public class CommandHistory implements History {
-    private static final String MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE = "Length of Command History must atleast be 1";
+    private static final String MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE = "Length of Command History must at least be 1";
 
     private List<String> commandHistory;
     private int currentCommandIndex;

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -110,11 +110,11 @@ public class CommandHistory implements History {
 
     @Override
     public Optional<String> nextCommand() {
-        hasReturnedCurrentCommandBefore = false;
         if (isAbleToReturnNextCommand()) {
             currentCommandIndex++;
             return Optional.of(commandHistory.get(currentCommandIndex));
         } else {
+            hasReturnedCurrentCommandBefore = false;
             return Optional.empty();
         }
     }

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -22,7 +22,9 @@ public class CommandHistory implements History {
     // }
     // this is to prevent the first previousCommand() method call to
     // return commandHistory's 2nd last command instead of the last command
-    // will be reset to true if (newCommandsAdded || nextCommand() -> Optional.empty())
+    //
+    // will be set true after initial call of previousCommand()
+    // will be reset to false if (newCommandsAdded || nextCommand() -> Optional.empty())
     private boolean hasReturnedCurrentCommandBefore;
 
     /**

--- a/src/main/java/seedu/address/history/CommandHistory.java
+++ b/src/main/java/seedu/address/history/CommandHistory.java
@@ -1,0 +1,145 @@
+package seedu.address.history;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.history.exception.HistoryException;
+
+public class CommandHistory implements History {
+    private static final String MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE = "Length of Command History must atleast be 1";
+
+    private List<String> commandHistory;
+    private int currentCommandIndex;
+    private final int lengthLimit;
+
+    /**
+     * Constructor for CommandHistory
+     * @param lengthLimit length limit of command history. Must be strictly more than 0.
+     * @throws HistoryException if lengthLimit is less than or equals to 0.
+     */
+    public CommandHistory(int lengthLimit) throws HistoryException {
+        if (lengthLimit > 0) {
+            this.commandHistory = new ArrayList<>(lengthLimit);
+
+            // length limit is one-indexed similar to commandHistory.size()
+            this.lengthLimit = lengthLimit;
+
+            // since commandHistory is zero-indexed, initializing currentCommandIndex to -1 solves the zero-index issue
+            this.currentCommandIndex = -1;
+        } else {
+            throw new HistoryException(MESSAGE_LENGTH_LIMIT_AT_LEAST_ONE);
+        }
+    }
+
+    public int getCurrentCommandIndex() {
+        return currentCommandIndex;
+    }
+
+    public int getLengthLimit() {
+        return lengthLimit;
+    }
+
+    public List<String> getCommandHistory() {
+        return commandHistory;
+    }
+
+    private boolean isLimitReached() {
+        return commandHistory.size() == lengthLimit;
+    }
+
+    private boolean isWithinLengthLimit() {
+        return currentCommandIndex >= 0 && currentCommandIndex < lengthLimit;
+    }
+
+    private boolean isAbleToReturnNextCommand() {
+        return currentCommandIndex < commandHistory.size() - 1 && isWithinLengthLimit();
+    }
+
+    private boolean isAbleToReturnPreviousCommand() {
+        return currentCommandIndex > 0 && isWithinLengthLimit();
+    }
+
+    public boolean hasNextCommand() {
+        return currentCommandIndex < commandHistory.size() - 1;
+    }
+
+    @Override
+    public void addToHistory(String command) {
+        if (hasNextCommand()) {
+            // if there exist a next command,
+            // copy commandHistory[0] to commandHistory[currentCommandIndex],
+            // store it as the new commandHistory
+            // and append the new command.
+            commandHistory = commandHistory.subList(0, currentCommandIndex + 1);
+            this.currentCommandIndex++;
+            this.commandHistory.add(command);
+        } else if (isLimitReached()) {
+            this.commandHistory.remove(0);
+            this.commandHistory.add(command);
+        } else {
+            // when there is sufficient space for nextCommand to be added to history
+            this.currentCommandIndex++;
+            this.commandHistory.add(command);
+        }
+    }
+
+    @Override
+    public Optional<String> previousCommand() {
+        if (isAbleToReturnPreviousCommand()) {
+            currentCommandIndex--;
+            return Optional.of(commandHistory.get(currentCommandIndex));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<String> nextCommand() {
+        if (isAbleToReturnNextCommand()) {
+            currentCommandIndex++;
+            return Optional.of(commandHistory.get(currentCommandIndex));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<String> currentCommand() {
+        if (isWithinLengthLimit()) {
+            return Optional.of(commandHistory.get(currentCommandIndex));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commandHistory, currentCommandIndex, lengthLimit);
+    }
+
+    /**
+     * Returns true if both command history have the same commandHistory, currentCommandIndex and length limit.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof CommandHistory) {
+            CommandHistory c = (CommandHistory) o;
+            return c.getCommandHistory().equals(this.commandHistory)
+                    && c.getCurrentCommandIndex() == this.currentCommandIndex
+                    && c.getLengthLimit() == this.lengthLimit;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return commandHistory.toString()
+                + " || Length Limit: " + lengthLimit
+                + " || Current Index: " + currentCommandIndex;
+    }
+}

--- a/src/main/java/seedu/address/history/History.java
+++ b/src/main/java/seedu/address/history/History.java
@@ -6,18 +6,21 @@ public interface History {
 
     /**
      * Adds input to history.
+     * Removes oldest history when there is an overflow.
      * @param command input for adding to history.
      */
     void addToHistory(String command);
 
     /**
      * Provides previous command, if any.
+     * Decreases the currentCommandIndex by 1.
      * @return an Optional of the previous command.
      */
     Optional<String> previousCommand();
 
     /**
      * Provides next command, if any.
+     * Increments the currentCommandIndex by 1.
      * @return an Optional of the next command.
      */
     Optional<String> nextCommand();

--- a/src/main/java/seedu/address/history/History.java
+++ b/src/main/java/seedu/address/history/History.java
@@ -1,0 +1,30 @@
+package seedu.address.history;
+
+import java.util.Optional;
+
+public interface History {
+
+    /**
+     * Adds input to history.
+     * @param command input for adding to history.
+     */
+    void addToHistory(String command);
+
+    /**
+     * Provides previous command, if any.
+     * @return an Optional of the previous command.
+     */
+    Optional<String> previousCommand();
+
+    /**
+     * Provides next command, if any.
+     * @return an Optional of the next command.
+     */
+    Optional<String> nextCommand();
+
+    /**
+     * Provides current command, if any.
+     * @return an Optional of the current command.
+     */
+    Optional<String> currentCommand();
+}

--- a/src/main/java/seedu/address/history/exception/HistoryException.java
+++ b/src/main/java/seedu/address/history/exception/HistoryException.java
@@ -1,0 +1,7 @@
+package seedu.address.history.exception;
+
+public class HistoryException extends Exception {
+    public HistoryException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/seedu/address/model/delivery/Delivery.java
+++ b/src/main/java/seedu/address/model/delivery/Delivery.java
@@ -2,6 +2,8 @@ package seedu.address.model.delivery;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 /**
  * Represents a delivery in the delivery book
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -55,6 +57,11 @@ public class Delivery {
         return otherDelivery != null
                 && otherDelivery.getName().equals(getName())
                 && otherDelivery.getPhone().equals(getPhone());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, phone, address, order);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -4,8 +4,10 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.history.CommandHistory;
+import seedu.address.history.History;
 import seedu.address.history.exception.HistoryException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.results.CommandResult;
@@ -20,7 +22,7 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
-    private final CommandHistory history;
+    private final History history;
 
     @FXML
     private TextField commandTextField;
@@ -39,20 +41,7 @@ public class CommandBox extends UiPart<Region> {
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
 
-        commandTextField.setOnKeyPressed(event -> {
-            switch (event.getCode()) {
-            case UP:
-                commandTextField.setText(history.previousCommand().orElse(""));
-                break;
-
-            case DOWN:
-                commandTextField.setText(history.nextCommand().orElse(""));
-                break;
-
-            default:
-                break;
-            }
-        });
+        commandTextField.setOnKeyPressed(event -> handleHistoryNavigation(event));
     }
 
     /**
@@ -85,6 +74,25 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        }
+    }
+
+    /**
+     * Handles the Up/Down button pressed event.
+     */
+    @FXML
+    private void handleHistoryNavigation(KeyEvent event) {
+        switch (event.getCode()) {
+        case UP:
+            commandTextField.setText(history.previousCommand().orElse(""));
+            break;
+
+        case DOWN:
+            commandTextField.setText(history.nextCommand().orElse(""));
+            break;
+
+        default:
+            break;
         }
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -47,8 +47,8 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Makes a {@code CommandHistory} object with COMMAND_HISTORY_LIMIT
-     * @see seedu.address.ui.CommandBox#COMMAND_HISTORY_LIMIT
      * @return {@code CommandHistory} object
+     * @see seedu.address.ui.CommandBox#COMMAND_HISTORY_LIMIT
      */
     private CommandHistory makeCommandHistory() {
         CommandHistory tempHistory;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -20,6 +20,7 @@ public class CommandBox extends UiPart<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
+    private static final int COMMAND_HISTORY_LIMIT = 20;
 
     private final CommandExecutor commandExecutor;
     private final History history;
@@ -51,7 +52,7 @@ public class CommandBox extends UiPart<Region> {
     private CommandHistory makeCommandHistory() {
         CommandHistory tempHistory;
         try {
-            tempHistory = new CommandHistory(20);
+            tempHistory = new CommandHistory(COMMAND_HISTORY_LIMIT);
         } catch (HistoryException historyException) {
             tempHistory = null;
             System.err.println(historyException);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -46,7 +46,8 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
-     * Makes a {@code CommandHistory} object with limit 20
+     * Makes a {@code CommandHistory} object with COMMAND_HISTORY_LIMIT
+     * @see seedu.address.ui.CommandBox#COMMAND_HISTORY_LIMIT
      * @return {@code CommandHistory} object
      */
     private CommandHistory makeCommandHistory() {

--- a/src/test/java/seedu/address/history/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/history/CommandHistoryTest.java
@@ -90,11 +90,11 @@ public class CommandHistoryTest {
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
         // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -177,11 +177,11 @@ public class CommandHistoryTest {
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
         // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -236,13 +236,13 @@ public class CommandHistoryTest {
         // if only command in history, return that command
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
-        assertEquals(optionalSecondCommand, cTwo.previousCommand());
+        // previous command of cTwo should be firstCommand as it's not the first time
+        // we are applying previousCommand after addingToHistory
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
-        assertEquals(optionalSecondCommand, cThree.previousCommand());
+        // we are applying previousCommand after addingToHistory
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
     }
 
     @Test
@@ -292,11 +292,11 @@ public class CommandHistoryTest {
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
         // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -334,11 +334,11 @@ public class CommandHistoryTest {
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
         // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -426,11 +426,11 @@ public class CommandHistoryTest {
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
         // previous command of cTwo should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
         // previous command of cThree should be secondCommand as it's the first time
-        // we are applying previousCommand after any other commands
+        // we are applying previousCommand after addingToHistory
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================

--- a/src/test/java/seedu/address/history/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/history/CommandHistoryTest.java
@@ -86,34 +86,34 @@ public class CommandHistoryTest {
         // cThree Current index = 1;
         //===========================================================
 
-        // cOne has limit of 1, thus there is no previousCommand
-        assertEquals(Optional.empty(), cOne.previousCommand());
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be firstCommand
-        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be firstCommand
-        assertEquals(optionalFirstCommand, cThree.previousCommand());
+        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
         // cOne = {secondCommand};
         // cOne Current index = 0;
         //
         // cTwo = {firstCommand, secondCommand};
-        // cTwo Current index = 0;
+        // cTwo Current index = 1;
         //
         // cThree = {firstCommand, secondCommand};
-        // cThree Current index = 0;
+        // cThree Current index = 1;
         //===============================================================
 
         // cOne has limit of 1, thus there is no previousCommand
         assertEquals(Optional.empty(), cOne.nextCommand());
 
-        // next command of cTwo should be secondCommand
-        assertEquals(optionalSecondCommand, cTwo.nextCommand());
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
 
-        // next command of cThree should be secondCommand
-        assertEquals(optionalSecondCommand, cThree.nextCommand());
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
 
         //================== AFTER 1x NEXT COMMAND ==================
         // cOne = {secondCommand};
@@ -171,34 +171,34 @@ public class CommandHistoryTest {
         // cThree Current index = 1;
         //==============================================================
 
-        // cOne has limit of 1, thus there is no previousCommand
-        assertEquals(Optional.empty(), cOne.previousCommand());
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be firstCommand
-        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be firstCommand
-        assertEquals(optionalFirstCommand, cThree.previousCommand());
+        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
         // cOne = {secondCommand};
         // cOne Current index = 0;
         //
         // cTwo = {firstCommand, secondCommand};
-        // cTwo Current index = 0;
+        // cTwo Current index = 1;
         //
         // cThree = {firstCommand, secondCommand};
-        // cThree Current index = 0;
+        // cThree Current index = 1;
         //===============================================================
 
         // cOne has limit of 1, thus there is no nextCommand
         assertEquals(Optional.empty(), cOne.nextCommand());
 
-        // nextCommand of cTwo should be secondCommand
-        assertEquals(optionalSecondCommand, cTwo.nextCommand());
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
 
-        // nextCommand of cThree should be secondCommand
-        assertEquals(optionalSecondCommand, cThree.nextCommand());
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
 
         //==================== AFTER 1x NEXT COMMAND ====================
         // cOne = {secondCommand};
@@ -211,24 +211,24 @@ public class CommandHistoryTest {
         // cThree Current index = 1;
         //===============================================================
 
-        // cOne has limit of 1, thus there is no previousCommand
-        assertEquals(Optional.empty(), cOne.previousCommand());
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be firstCommand
-        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be firstCommand
-        assertEquals(optionalFirstCommand, cThree.previousCommand());
+        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
         // cOne = {secondCommand};
         // cOne Current index = 0;
         //
         // cTwo = {firstCommand, secondCommand};
-        // cTwo Current index = 0;
+        // cTwo Current index = 1;
         //
         // cThree = {firstCommand, secondCommand};
-        // cThree Current index = 0;
+        // cThree Current index = 1;
         //===============================================================
     }
 
@@ -238,6 +238,7 @@ public class CommandHistoryTest {
         String secondCommand = "SecondCommand";
 
         Optional<String> optionalFirstCommand = Optional.of(firstCommand);
+        Optional<String> optionalSecondCommand = Optional.of(secondCommand);
 
         CommandHistory cOne = new CommandHistory(1);
         CommandHistory cTwo = new CommandHistory(2);
@@ -268,12 +269,28 @@ public class CommandHistoryTest {
         cTwo.addToHistory(firstCommand);
         cThree.addToHistory(firstCommand);
 
+        //================== AFTER ADDING FIRST COMMAND ==================
+        // cOne = {firstCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand};
+        // cThree Current index = 0;
+        //=================================================================
+
+        // if only command in history, return that command
+        assertEquals(optionalFirstCommand, cOne.previousCommand());
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
         // Adding secondCommand
         cOne.addToHistory(secondCommand);
         cTwo.addToHistory(secondCommand);
         cThree.addToHistory(secondCommand);
 
-        //================== AFTER ADDING TO HISTORY ==================
+        //================== AFTER ADDING SECOND COMMAND ==================
         // cOne = {secondCommand};
         // cOne Current index = 0;
         //
@@ -282,15 +299,35 @@ public class CommandHistoryTest {
         //
         // cThree = {firstCommand, secondCommand};
         // cThree Current index = 1;
-        //==============================================================
+        //=================================================================
 
-        // cOne has limit of 1, thus there is no previousCommand
-        assertEquals(Optional.empty(), cOne.previousCommand());
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be firstCommand
+        // previous command of cTwo should be secondCommand as it's the first time we're prompting previousCommand
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be secondCommand as it's the first time we're prompting previousCommand
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===============================================================
+
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand as it's not the first time we're prompting previousCommand
         assertEquals(optionalFirstCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be firstCommand
+        // previous command of cTwo should be firstCommand as it's not the first time we're prompting previousCommand
         assertEquals(optionalFirstCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -303,12 +340,6 @@ public class CommandHistoryTest {
         // cThree = {firstCommand, secondCommand};
         // cThree Current index = 0;
         //===============================================================
-
-        // since now current index = 0, there is no previous command
-        assertEquals(Optional.empty(), cTwo.previousCommand());
-
-        // since now current index = 0, there is no previous command
-        assertEquals(Optional.empty(), cThree.previousCommand());
     }
 
     @Test

--- a/src/test/java/seedu/address/history/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/history/CommandHistoryTest.java
@@ -89,10 +89,12 @@ public class CommandHistoryTest {
         // if only command in history, return that command
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -128,7 +130,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void previousCommandThenNextCommandThenPreviousCommand() throws HistoryException {
+    public void previousCommandThenPreviousCommandThenNextCommandThenPreviousCommand() throws HistoryException {
         String firstCommand = "FirstCommand";
         String secondCommand = "SecondCommand";
 
@@ -174,10 +176,127 @@ public class CommandHistoryTest {
         // if only command in history, return that command
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===============================================================
+
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand as it's not the first time we are applying previousCommand
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be firstCommand as it's not the first time we are applying previousCommand
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 0;
+        //===============================================================
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // next Item in both cTwo and cThree should be secondCommand
+        assertEquals(optionalSecondCommand, cTwo.nextCommand());
+        assertEquals(optionalSecondCommand, cThree.nextCommand());
+
+        //==================== AFTER 1x NEXT COMMAND ====================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===============================================================
+
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
+
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
+        assertEquals(optionalSecondCommand, cThree.previousCommand());
+    }
+
+    @Test
+    public void previousCommandThenNextCommandThenPreviousCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        Optional<String> optionalSecondCommand = Optional.of(secondCommand);
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==============================================================
+
+        // if only command in history, return that command
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
+
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
+        assertEquals(optionalSecondCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -214,10 +333,12 @@ public class CommandHistoryTest {
         // if only command in history, return that command
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be secondCommand as it's the first time we are applying previousCommand
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================
@@ -304,10 +425,12 @@ public class CommandHistoryTest {
         // if only command in history, return that command
         assertEquals(optionalSecondCommand, cOne.previousCommand());
 
-        // previous command of cTwo should be secondCommand as it's the first time we're prompting previousCommand
+        // previous command of cTwo should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cTwo.previousCommand());
 
-        // previous command of cThree should be secondCommand as it's the first time we're prompting previousCommand
+        // previous command of cThree should be secondCommand as it's the first time
+        // we are applying previousCommand after any other commands
         assertEquals(optionalSecondCommand, cThree.previousCommand());
 
         //================== AFTER 1x PREVIOUS COMMAND ==================

--- a/src/test/java/seedu/address/history/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/history/CommandHistoryTest.java
@@ -340,6 +340,15 @@ public class CommandHistoryTest {
         // cThree = {firstCommand, secondCommand};
         // cThree Current index = 0;
         //===============================================================
+
+        // since currentIndex is 0, return secondCommand for cOne
+        assertEquals(optionalSecondCommand, cOne.previousCommand());
+
+        // since currentIndex is 0, return firstCommand for cTwo
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // since currentIndex is 0, return firstCommand for cThree
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
     }
 
     @Test

--- a/src/test/java/seedu/address/history/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/history/CommandHistoryTest.java
@@ -1,0 +1,568 @@
+package seedu.address.history;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.history.exception.HistoryException;
+
+public class CommandHistoryTest {
+
+    @Test
+    public void constructorInvalidLengthLimit_throwsHistoryException() {
+        // instantiating with a negative limit -> throws HistoryException
+        assertThrows(HistoryException.class, () -> new CommandHistory(-1));
+
+        // instantiating with a limit of 0 -> throws HistoryException
+        assertThrows(HistoryException.class, () -> new CommandHistory(0));
+    }
+
+    @Test
+    public void nextCommandThenPreviousCommandThenNextCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        Optional<String> optionalFirstCommand = Optional.of(firstCommand);
+        Optional<String> optionalSecondCommand = Optional.of(secondCommand);
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==============================================================
+
+        // cOne has limit of 1, thus there is no nextCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
+
+        //================== AFTER 1x NEXT COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===========================================================
+
+        // cOne has limit of 1, thus there is no previousCommand
+        assertEquals(Optional.empty(), cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be firstCommand
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 0;
+        //===============================================================
+
+        // cOne has limit of 1, thus there is no previousCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // next command of cTwo should be secondCommand
+        assertEquals(optionalSecondCommand, cTwo.nextCommand());
+
+        // next command of cThree should be secondCommand
+        assertEquals(optionalSecondCommand, cThree.nextCommand());
+
+        //================== AFTER 1x NEXT COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===========================================================
+    }
+
+    @Test
+    public void previousCommandThenNextCommandThenPreviousCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        Optional<String> optionalFirstCommand = Optional.of(firstCommand);
+        Optional<String> optionalSecondCommand = Optional.of(secondCommand);
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==============================================================
+
+        // cOne has limit of 1, thus there is no previousCommand
+        assertEquals(Optional.empty(), cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be firstCommand
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 0;
+        //===============================================================
+
+        // cOne has limit of 1, thus there is no nextCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // nextCommand of cTwo should be secondCommand
+        assertEquals(optionalSecondCommand, cTwo.nextCommand());
+
+        // nextCommand of cThree should be secondCommand
+        assertEquals(optionalSecondCommand, cThree.nextCommand());
+
+        //==================== AFTER 1x NEXT COMMAND ====================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===============================================================
+
+        // cOne has limit of 1, thus there is no previousCommand
+        assertEquals(Optional.empty(), cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be firstCommand
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 0;
+        //===============================================================
+    }
+
+    @Test
+    public void previousCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        Optional<String> optionalFirstCommand = Optional.of(firstCommand);
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        // since cOne is empty, there is no previousCommand
+        assertEquals(Optional.empty(), cOne.previousCommand());
+
+        // since cTwo is empty, there is no previousCommand
+        assertEquals(Optional.empty(), cTwo.previousCommand());
+
+        // since cThree is empty, there is no previousCommand
+        assertEquals(Optional.empty(), cThree.previousCommand());
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==============================================================
+
+        // cOne has limit of 1, thus there is no previousCommand
+        assertEquals(Optional.empty(), cOne.previousCommand());
+
+        // previous command of cTwo should be firstCommand
+        assertEquals(optionalFirstCommand, cTwo.previousCommand());
+
+        // previous command of cThree should be firstCommand
+        assertEquals(optionalFirstCommand, cThree.previousCommand());
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 0;
+        //===============================================================
+
+        // since now current index = 0, there is no previous command
+        assertEquals(Optional.empty(), cTwo.previousCommand());
+
+        // since now current index = 0, there is no previous command
+        assertEquals(Optional.empty(), cThree.previousCommand());
+    }
+
+    @Test
+    public void nextCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        // since cOne is empty, there is no nextCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // since cTwo is empty, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
+
+        // since cThree is empty, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==============================================================
+
+        // cOne has limit of 1, thus there is no nextCommand
+        assertEquals(Optional.empty(), cOne.nextCommand());
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
+
+        //================== AFTER 1x NEXT COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //===========================================================
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cTwo.nextCommand());
+
+        // since currentCommandIndex is at the end, there is no nextCommand
+        assertEquals(Optional.empty(), cThree.nextCommand());
+    }
+
+    @Test
+    public void currentCommand() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+
+        Optional<String> optionalFirstCommand = Optional.of(firstCommand);
+        Optional<String> optionalSecondCommand = Optional.of(secondCommand);
+
+        CommandHistory cOne = new CommandHistory(1);
+        CommandHistory cTwo = new CommandHistory(2);
+        CommandHistory cThree = new CommandHistory(3);
+
+        //========================= PRIOR TO ADDING =========================
+        // cOne = {};
+        // cOne Current index = -1;
+        //
+        // cTwo = {};
+        // cTwo Current index = -1;
+        //
+        // cThree = {};
+        // cThree Current index = -1;
+        //===================================================================
+
+        assertEquals(Optional.empty(), cOne.currentCommand());
+        assertEquals(Optional.empty(), cTwo.currentCommand());
+        assertEquals(Optional.empty(), cThree.currentCommand());
+
+        // Adding firstCommand
+        cOne.addToHistory(firstCommand);
+        cTwo.addToHistory(firstCommand);
+        cThree.addToHistory(firstCommand);
+
+        //=================== AFTER ADDING FIRST COMMAND ===================
+        // cOne = {firstCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand};
+        // cTwo Current index = 0;
+        //
+        // cThree = {firstCommand};
+        // cThree Current index = 0;
+        //==================================================================
+
+        assertEquals(optionalFirstCommand, cOne.currentCommand());
+        assertEquals(optionalFirstCommand, cTwo.currentCommand());
+        assertEquals(optionalFirstCommand, cThree.currentCommand());
+
+
+        // Adding secondCommand
+        cOne.addToHistory(secondCommand);
+        cTwo.addToHistory(secondCommand);
+        cThree.addToHistory(secondCommand);
+
+        //================== AFTER ADDING SECOND COMMAND ==================
+        // cOne = {secondCommand};
+        // cOne Current index = 0;
+        //
+        // cTwo = {firstCommand, secondCommand};
+        // cTwo Current index = 1;
+        //
+        // cThree = {firstCommand, secondCommand};
+        // cThree Current index = 1;
+        //==================================================================
+
+        assertEquals(optionalSecondCommand, cOne.currentCommand());
+        assertEquals(optionalSecondCommand, cTwo.currentCommand());
+        assertEquals(optionalSecondCommand, cThree.currentCommand());
+    }
+
+    @Test
+    public void addToHistory() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+        String thirdCommand = "ThirdCommand";
+
+        CommandHistory cIsLimitReached = new CommandHistory(1);
+
+        cIsLimitReached.addToHistory(firstCommand);
+        cIsLimitReached.addToHistory(secondCommand);
+
+        // c == {secondCommand};
+        // c Current index = 0;
+        // when overflow, addToHistory should pop firstCommand, thus size() == 1
+        assertEquals(cIsLimitReached.getCommandHistory().size(), 1);
+
+        // since length limit is 1, the only item left inside commandHistory should be secondCommand
+        assertEquals(cIsLimitReached.getCommandHistory().get(0), secondCommand);
+
+
+        //======================== ONE MORE TIME FOR GOOD MEASURE ========================
+
+        cIsLimitReached.addToHistory(thirdCommand);
+        // c = {thirdCommand}
+        // when overflow, addToHistory should now pop secondCommand, thus size() == 1
+        assertEquals(1, cIsLimitReached.getCommandHistory().size());
+
+        // since length limit is 1, the only item left inside commandHistory should be thirdCommand
+        assertEquals(thirdCommand, cIsLimitReached.getCommandHistory().get(0));
+    }
+
+    @Test
+    public void overwrite_existing_commandHistory() throws HistoryException {
+        String firstCommand = "FirstCommand";
+        String secondCommand = "SecondCommand";
+        String thirdCommand = "ThirdCommand";
+        String fourthCommand = "FourthCommand";
+        CommandHistory cThree = new CommandHistory(3);
+
+        Optional<String> optionalFourthCommand = Optional.of(fourthCommand);
+
+        cThree.addToHistory(firstCommand);
+        cThree.addToHistory(secondCommand);
+        cThree.addToHistory(thirdCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cThree = {firstCommand, secondCommand, thirdCommand};
+        // cThree Current index = 2;
+        //==============================================================
+
+        cThree.previousCommand();
+
+        //================== AFTER 1x PREVIOUS COMMAND ==================
+        // cThree = {firstCommand, secondCommand, thirdCommand};
+        // cThree Current index = 1;
+        //===============================================================
+
+        cThree.addToHistory(fourthCommand);
+
+        //================== AFTER ADDING TO HISTORY ==================
+        // cThree = {firstCommand, secondCommand, fourthCommand};
+        // cThree Current index = 2;
+        //==============================================================
+
+        assertEquals(optionalFourthCommand, cThree.currentCommand());
+    }
+
+    @Test
+    public void equals() throws HistoryException {
+        CommandHistory emptyCommandHistory = new CommandHistory(10);
+        CommandHistory emptyCommandHistoryCopy = emptyCommandHistory;
+        CommandHistory otherEmptyCommandHistoryButSame = new CommandHistory(10);
+        CommandHistory differentEmptyCommandHistory = new CommandHistory(20);
+
+        CommandHistory filledCommandHistory = new CommandHistory(10);
+        filledCommandHistory.addToHistory("PLACEHOLDER");
+
+        CommandHistory filledCommandHistoryCopy = filledCommandHistory;
+
+        CommandHistory sameFilledCommandHistory = new CommandHistory(10);
+        sameFilledCommandHistory.addToHistory("PLACEHOLDER");
+
+        CommandHistory differentFilledCommandHistory = new CommandHistory(10);
+        differentFilledCommandHistory.addToHistory("DIFFERENT");
+
+        // same object -> returns true
+        assertTrue(emptyCommandHistory.equals(emptyCommandHistoryCopy));
+        assertTrue(filledCommandHistory.equals(filledCommandHistoryCopy));
+
+        // same variable fields -> returns true
+        assertTrue(emptyCommandHistory.equals(otherEmptyCommandHistoryButSame));
+
+        // null -> returns false
+        assertFalse(emptyCommandHistory.equals(null));
+
+        // different command history -> returns false
+        assertFalse(emptyCommandHistory.equals(differentEmptyCommandHistory));
+
+        // empty != filled command history -> returns false
+        assertFalse(emptyCommandHistory.equals(filledCommandHistory));
+
+        // differently filled -> returns false
+        assertFalse(filledCommandHistory.equals(differentFilledCommandHistory));
+
+        // same fields -> returns true
+        assertTrue(filledCommandHistory.equals(sameFilledCommandHistory));
+    }
+
+}


### PR DESCRIPTION
Implemented History

CommandBox now has Window's command prompt Command History feature in the sense that:
1) Pressing arrow up key cycles through your past commands (if any)
2) Pressing arrow down key cycles through your finished commands (if any)

This implementation aligns with aiding our user's fast typist perk