### PR TITLE
Fix CommandHistory

### DIFF
--- a/src/main/java/seedu/address/history/HistoryManager.java
+++ b/src/main/java/seedu/address/history/HistoryManager.java
@@ -89,12 +89,14 @@ public class HistoryManager implements History {
         hasReturnedCurrentCommandBefore = false;
         if (hasNextCommand()) {
             // if there exist a next command,
-            // copy commandHistory[0] to commandHistory[currentCommandIndex],
-            // store it as the new commandHistory
-            // and append the new command.
-            commandHistory = commandHistory.subList(0, currentCommandIndex + 1);
-            this.currentCommandIndex++;
+            // append the new command and
+            // shift the currentCommandHistoryIndex to the end of the list
             this.commandHistory.add(command);
+            if (isLimitReached()) {
+                // if adding the new command hits the limit, pop the first command off
+                this.commandHistory.remove(0);
+            }
+            this.currentCommandIndex = commandHistory.size() - 1;
         } else if (isLimitReached()) {
             this.commandHistory.remove(0);
             this.commandHistory.add(command);

--- a/src/main/java/seedu/address/history/HistoryManager.java
+++ b/src/main/java/seedu/address/history/HistoryManager.java
@@ -87,24 +87,11 @@ public class HistoryManager implements History {
     @Override
     public void addToHistory(String command) {
         hasReturnedCurrentCommandBefore = false;
-        if (hasNextCommand()) {
-            // if there exist a next command,
-            // append the new command and
-            // shift the currentCommandHistoryIndex to the end of the list
-            this.commandHistory.add(command);
-            if (isLimitReached()) {
-                // if adding the new command hits the limit, pop the first command off
-                this.commandHistory.remove(0);
-            }
-            this.currentCommandIndex = commandHistory.size() - 1;
-        } else if (isLimitReached()) {
+        if (isLimitReached()) {
             this.commandHistory.remove(0);
-            this.commandHistory.add(command);
-        } else {
-            // when there is sufficient space for nextCommand to be added to history
-            this.currentCommandIndex++;
-            this.commandHistory.add(command);
         }
+        this.commandHistory.add(command);
+        this.currentCommandIndex = commandHistory.size() - 1;
     }
 
     @Override


### PR DESCRIPTION
Now commandHistory, when selecting a command that is not
in at the end of the list, will append the command
(pop the first command off if the limit is reached after
appending) and shift the currentCommandIndex till the end.