### PR TITLE
Fix Indexing for DeleteItem, DeleteDelivery, RemoveItem

### DIFF
--- a/src/main/java/seedu/address/logic/commands/deliverycommand/DeliveryDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverycommand/DeliveryDeleteCommand.java
@@ -39,8 +39,8 @@ public class DeliveryDeleteCommand extends DeliveryCommand {
         DeliveryModel deliveryModel = models.getDeliveryModel();
         List<Delivery> lastShownList = deliveryModel.getFilteredAndSortedDeliveryList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+        if (targetIndex.getZeroBased() >= lastShownList.size() || targetIndex.getZeroBased() < 0) {
+            throw new CommandException(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
         }
 
         Delivery deliveryToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/itemcommand/ItemDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/itemcommand/ItemDeleteCommand.java
@@ -39,7 +39,7 @@ public class ItemDeleteCommand extends ItemCommand {
         InventoryModel inventoryModel = models.getInventoryModel();
         List<Item> lastShownList = inventoryModel.getFilteredAndSortedItemList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+        if (targetIndex.getZeroBased() >= lastShownList.size() || targetIndex.getZeroBased() < 0) {
             throw new CommandException(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
         }
 

--- a/src/test/java/seedu/address/logic/commands/deliverycommand/DeliveryDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/deliverycommand/DeliveryDeleteCommandTest.java
@@ -46,7 +46,7 @@ public class DeliveryDeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(deliveryModel.getFilteredAndSortedDeliveryList().size() + 1);
         DeliveryDeleteCommand deleteCommand = new DeliveryDeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, deliveryModel, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, deliveryModel, Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class DeliveryDeleteCommandTest {
 
         DeliveryDeleteCommand deleteCommand = new DeliveryDeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, deliveryModel, Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, deliveryModel, Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
     }
 
     @Test


### PR DESCRIPTION
New Index means out of bounds is not handled my ParseException anymore,
added check conditions for DeleteItem, DeleteDelivery and RemoveItem